### PR TITLE
feat: restrict edit and clone by environment

### DIFF
--- a/env-config.json
+++ b/env-config.json
@@ -1,0 +1,11 @@
+{
+  "categoryName": "appIntegrator_environments",
+  "environments": [
+    { "categoryId": "dev", "categoryValues": { "allowEdit": true, "allowClone": true, "allowCreate": true } },
+    { "categoryId": "qa", "categoryValues": { "allowEdit": false, "allowClone": false, "allowCreate": false } },
+    { "categoryId": "uat", "categoryValues": { "allowEdit": false, "allowClone": false, "allowCreate": false } },
+    { "categoryId": "prod", "categoryValues": { "allowEdit": false, "allowClone": false, "allowCreate": false } },
+    { "categoryId": "uatdr", "categoryValues": { "allowEdit": false, "allowClone": false, "allowCreate": false } },
+    { "categoryId": "dr", "categoryValues": { "allowEdit": false, "allowClone": false, "allowCreate": false } }
+  ]
+}


### PR DESCRIPTION
## Summary
- add environment permission config and helper
- disable edit and clone actions outside permitted envs
- allow tagging APIs when cloning for searchable metadata

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab60631cd88322a98d3215c07d1ad0