### PR TITLE
Use image logos and prevent stats label wrapping

### DIFF
--- a/app-integrator-logo-dark.svg
+++ b/app-integrator-logo-dark.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <path d="M50 10A40 40 0 0 1 90 50L78 48A28 28 0 0 0 50 22Z" fill="#1E40AF"/>
+    <path d="M50 10A40 40 0 0 0 10 50L22 48A28 28 0 0 1 50 22Z" fill="#DC2626"/>
+    <path d="M50 90A40 40 0 0 1 10 50L22 52A28 28 0 0 0 50 78Z" fill="#16A34A"/>
+    <path d="M50 90A40 40 0 0 0 90 50L78 52A28 28 0 0 1 50 78Z" fill="#F59E0B"/>
+    <circle cx="50" cy="50" r="18" fill="#1F2937" stroke="#6B7280" stroke-width="2"/>
+    <path d="M45 45 L55 55 M55 45 L45 55" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/app-integrator-logo-light.svg
+++ b/app-integrator-logo-light.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <path d="M50 10A40 40 0 0 1 90 50L78 48A28 28 0 0 0 50 22Z" fill="#1E40AF"/>
+    <path d="M50 10A40 40 0 0 0 10 50L22 48A28 28 0 0 1 50 22Z" fill="#DC2626"/>
+    <path d="M50 90A40 40 0 0 1 10 50L22 52A28 28 0 0 0 50 78Z" fill="#16A34A"/>
+    <path d="M50 90A40 40 0 0 0 90 50L78 52A28 28 0 0 1 50 78Z" fill="#F59E0B"/>
+    <circle cx="50" cy="50" r="18" fill="#FFFFFF" stroke="#6B7280" stroke-width="2"/>
+    <path d="M45 45 L55 55 M55 45 L45 55" stroke="#1F2937" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/updated_app_api_in_google_v2.js
+++ b/updated_app_api_in_google_v2.js
@@ -28,6 +28,8 @@ import {
 } from 'lucide-react';
 
 import envConfig from './env-config.json';
+import logoLight from './app-integrator-logo-light.svg';
+import logoDark from './app-integrator-logo-dark.svg';
 
 const ENV_SETTINGS = Object.fromEntries(
   (envConfig.environments || []).map(e => [e.categoryId, e.categoryValues])
@@ -111,21 +113,6 @@ const SchemaMapper = ({ sourceSchema, targetSchema, mappings, onUpdateMappings, 
 
 
 // --- UTILITY & SHARED COMPONENTS ---
-
-// New SVG Logo based on user image
-const AppIntegratorLogo = ({ className = "w-8 h-8", theme = 'light' }) => (
-    <svg className={className} viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-        {/* Blue arc */}
-        <path d="M50 10A40 40 0 0 1 90 50L78 48A28 28 0 0 0 50 22Z" fill="#1E40AF" />
-        {/* Red arc */}
-        <path d="M90 50A40 40 0 0 1 50 90L52 78A28 28 0 0 0 78 50Z" fill="#DC2626" />
-        {/* Gray arc */}
-        <path d="M50 90A40 40 0 0 1 10 50L22 52A28 28 0 0 0 50 78Z" fill="#6B7280" />
-        {/* Center shape */}
-        <path d="M50 40L62 60H38Z" fill={theme === 'dark' ? '#FFFFFF' : '#000000'} />
-    </svg>
-);
-
 
 // Toast Notification Component
 const Toast = ({ message, type = 'info', onClose }) => {
@@ -2330,13 +2317,13 @@ const Dashboard = ({ configs, onSelectConfig, onCreateNew, onDeleteConfig, onClo
           theme === 'dark' ? 'border-blue-500 text-white' : 'border-blue-600 text-gray-900'
         }`}>
           <span className="text-2xl font-bold">{totalConfigs}</span>
-          <span className="text-xs mt-1 text-center">Total Configs</span>
+          <span className="text-xs mt-1 text-center whitespace-nowrap">Total Configs</span>
         </div>
         <div className={`flex flex-col items-center justify-center w-24 h-24 rounded-full border-4 ${
           theme === 'dark' ? 'border-green-500 text-white' : 'border-green-600 text-gray-900'
         }`}>
           <span className="text-2xl font-bold">{totalPublished}</span>
-          <span className="text-xs mt-1 text-center">Published</span>
+          <span className="text-xs mt-1 text-center whitespace-nowrap">Published</span>
         </div>
       </div>
 
@@ -4818,7 +4805,7 @@ const App = () => {
       <header className={`flex items-center justify-between px-4 py-2 ${theme === 'dark' ? 'bg-gray-900 border-gray-700' : 'bg-white border-gray-200'} border-b`}>
         <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">
-                <AppIntegratorLogo theme={theme} />
+                <img src={theme === 'dark' ? logoDark : logoLight} alt="App Integrator Logo" className="w-8 h-8" />
                 <h1 className={`font-bold text-xl uppercase ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>App Integrator</h1>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- replace generated logo component with image-based logos for light and dark themes
- keep dashboard statistics labels on a single line with `whitespace-nowrap`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab742fbbdc8322b683d2fee71f50b6