### PR TITLE
fix: wrap next image component

### DIFF
--- a/components/core/Image.js
+++ b/components/core/Image.js
@@ -1,0 +1,5 @@
+import NextImage from 'next/image';
+
+const Image = NextImage.default || NextImage;
+
+export default Image;

--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import Image from '@/components/core/Image';
 
 export default function Header() {
   return (


### PR DESCRIPTION
## Summary
- add core Image wrapper to normalize next/image export
- use core Image in Header to avoid invalid element runtime error

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac09520ba48322b85a0e3dabfde938