### PR TITLE
refactor: normalize transform serialization

### DIFF
--- a/updated_app_api_in_google_v2.js
+++ b/updated_app_api_in_google_v2.js
@@ -446,8 +446,14 @@ const transformConfigToUserFormat = (config) => {
 
                 case 'filter':
                     transformations.push({
-                        type: 'filter',
-                        rules: [{ expression: node.data.filterCondition || 'condition not set' }]
+                        op: 'filter',
+                        target: '',
+                        config: {
+                            rules: [
+                                { expression: node.data.filterCondition || 'condition not set' }
+                            ]
+                        },
+                        onError: node.data.onError || 'continue'
                     });
                     break;
 
@@ -463,16 +469,21 @@ const transformConfigToUserFormat = (config) => {
                             limit: node.data.limit,
                             pivot: node.data.pivot,
                             rollup: node.data.rollup || false
-                        }
+                        },
+                        onError: node.data.onError || 'continue'
                     });
                     break;
 
                 case 'condition':
-                     transformations.push({
-                        type: 'condition',
-                        if: node.data.if || { field: "status", operator: "equals", value: "active" },
-                        then: node.data.then || { set: { "isActive": true } },
-                        else: node.data.else || { set: { "isActive": false } }
+                    transformations.push({
+                        op: 'condition',
+                        target: '',
+                        config: {
+                            if: node.data.if || { field: "status", operator: "equals", value: "active" },
+                            then: node.data.then || { set: { "isActive": true } },
+                            else: node.data.else || { set: { "isActive": false } }
+                        },
+                        onError: node.data.onError || 'continue'
                     });
                     break;
 


### PR DESCRIPTION
## Summary
- unify non-op nodes (filter, group_by, condition) with registry-style transform steps
- ensure each step serializes as `{ op, target, config, onError }` for lossless export/import

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac698733e48322af821524b783655d