### PR TITLE
Add flatten/unflatten transform operations with runtime and tests

### DIFF
--- a/transformRuntime.js
+++ b/transformRuntime.js
@@ -1,0 +1,96 @@
+// Simple transformation runtime with flatten/unflatten support
+function flatten(obj, { delimiter = '.', depth = 0, preserveArrays = false } = {}) {
+  const maxDepth = depth && depth > 0 ? depth : Infinity;
+  const result = {};
+  function recurse(value, path, currentDepth) {
+    const isObject = value && typeof value === 'object';
+    const isArray = Array.isArray(value);
+    if (
+      isObject &&
+      currentDepth < maxDepth &&
+      (!isArray || !preserveArrays)
+    ) {
+      const entries = isArray ? value.entries() : Object.entries(value);
+      for (const [k, v] of entries) {
+        const newPath = path ? `${path}${delimiter}${k}` : String(k);
+        recurse(v, newPath, currentDepth + 1);
+      }
+    } else {
+      if (path) result[path] = value;
+    }
+  }
+  recurse(obj, '', 0);
+  return result;
+}
+
+function unflatten(obj, { delimiter = '.', overwrite = false } = {}) {
+  const result = {};
+  outer: for (const [compound, value] of Object.entries(obj || {})) {
+    const keys = compound.split(delimiter);
+    let current = result;
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (i === keys.length - 1) {
+        if (!overwrite && Object.prototype.hasOwnProperty.call(current, key)) {
+          continue outer;
+        }
+        current[key] = value;
+      } else {
+        if (!current[key] || typeof current[key] !== 'object') {
+          if (overwrite) {
+            current[key] = {};
+          } else {
+            continue outer;
+          }
+        }
+        current = current[key];
+      }
+    }
+  }
+  return result;
+}
+
+function getByPath(obj, path) {
+  if (!path) return obj;
+  return path.split('.').reduce((o, k) => (o ? o[k] : undefined), obj);
+}
+
+function setByPath(obj, path, value) {
+  if (!path) return value;
+  const parts = path.split('.');
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (!current[part] || typeof current[part] !== 'object') {
+      current[part] = {};
+    }
+    current = current[part];
+  }
+  current[parts[parts.length - 1]] = value;
+  return obj;
+}
+
+function executeTransformation(data, t) {
+  const { op, target = '', config = {} } = t || {};
+  let working = JSON.parse(JSON.stringify(data || {}));
+  switch (op) {
+    case 'flatten': {
+      const val = getByPath(working, target);
+      const flat = flatten(val, config);
+      working = target ? setByPath(working, target, flat) : flat;
+      break;
+    }
+    case 'unflatten': {
+      const val = getByPath(working, target);
+      const nested = unflatten(val, config);
+      working = target ? setByPath(working, target, nested) : nested;
+      break;
+    }
+    default:
+      break;
+  }
+  return working;
+}
+
+module.exports = { flatten, unflatten, executeTransformation };
+

--- a/transformRuntime.test.js
+++ b/transformRuntime.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const { executeTransformation, unflatten } = require('./transformRuntime');
+
+// Round-trip flatten -> unflatten
+const original = {
+  user: { name: 'Alice', address: { city: 'LA' } },
+  tags: ['a', 'b']
+};
+
+const flattened = executeTransformation(original, {
+  op: 'flatten',
+  target: '',
+  config: { delimiter: '.', depth: 0, preserveArrays: true }
+});
+
+const roundTrip = executeTransformation(flattened, {
+  op: 'unflatten',
+  target: '',
+  config: { delimiter: '.', overwrite: true }
+});
+
+assert.deepStrictEqual(roundTrip, original, 'round-trip flatten/unflatten');
+
+// Conflict handling with overwrite
+const flatInput = { a: 1, 'a.b': 2 };
+const noOverwrite = unflatten(flatInput, { delimiter: '.', overwrite: false });
+assert.deepStrictEqual(noOverwrite, { a: 1 }, 'no overwrite should keep existing value');
+
+const yesOverwrite = unflatten(flatInput, { delimiter: '.', overwrite: true });
+assert.deepStrictEqual(yesOverwrite, { a: { b: 2 } }, 'overwrite should replace value');
+
+console.log('All runtime tests passed');
+

--- a/updated_app_api_in_google_v2.js
+++ b/updated_app_api_in_google_v2.js
@@ -58,6 +58,14 @@ const TRANSFORM_OPS = {
   array_take: {
     label: 'Array Take',
     defaultConfig: { count: 1 }
+  },
+  flatten: {
+    label: 'Flatten',
+    defaultConfig: { delimiter: '.', depth: 0, preserveArrays: false }
+  },
+  unflatten: {
+    label: 'Unflatten',
+    defaultConfig: { delimiter: '.', overwrite: false }
   }
 };
 
@@ -5190,6 +5198,61 @@ const NodePropertiesPanel = ({ node, onUpdate, onClose, theme, showToast, config
                           onChange={(e) => updateTransformation(transform.id, { config: { count: Number(e.target.value) } })}
                           className={`w-full px-2 py-1 text-sm rounded border ${ theme === 'dark' ? 'bg-gray-800 border-gray-600 text-white' : 'bg-white border-gray-300' } ${isReadOnly ? 'bg-gray-100 dark:bg-gray-800' : ''}`}
                         />
+                      )}
+
+                      {transform.op === 'flatten' && (
+                        <div className="space-y-2">
+                          <input
+                            type="text"
+                            placeholder="Delimiter"
+                            value={transform.config.delimiter || '.'}
+                            readOnly={isReadOnly}
+                            onChange={(e) => updateTransformation(transform.id, { config: { delimiter: e.target.value } })}
+                            className={`w-full px-2 py-1 text-sm rounded border ${ theme === 'dark' ? 'bg-gray-800 border-gray-600 text-white' : 'bg-white border-gray-300' } ${isReadOnly ? 'bg-gray-100 dark:bg-gray-800' : ''}`}
+                          />
+                          <input
+                            type="number"
+                            min="0"
+                            placeholder="Depth (0 = unlimited)"
+                            value={transform.config.depth ?? 0}
+                            readOnly={isReadOnly}
+                            onChange={(e) => updateTransformation(transform.id, { config: { depth: Number(e.target.value) } })}
+                            className={`w-full px-2 py-1 text-sm rounded border ${ theme === 'dark' ? 'bg-gray-800 border-gray-600 text-white' : 'bg-white border-gray-300' } ${isReadOnly ? 'bg-gray-100 dark:bg-gray-800' : ''}`}
+                          />
+                          <label className="flex items-center gap-2 text-xs">
+                            <input
+                              type="checkbox"
+                              checked={transform.config.preserveArrays || false}
+                              disabled={isReadOnly}
+                              onChange={(e) => updateTransformation(transform.id, { config: { preserveArrays: e.target.checked } })}
+                              className="rounded"
+                            />
+                            Preserve arrays
+                          </label>
+                        </div>
+                      )}
+
+                      {transform.op === 'unflatten' && (
+                        <div className="space-y-2">
+                          <input
+                            type="text"
+                            placeholder="Delimiter"
+                            value={transform.config.delimiter || '.'}
+                            readOnly={isReadOnly}
+                            onChange={(e) => updateTransformation(transform.id, { config: { delimiter: e.target.value } })}
+                            className={`w-full px-2 py-1 text-sm rounded border ${ theme === 'dark' ? 'bg-gray-800 border-gray-600 text-white' : 'bg-white border-gray-300' } ${isReadOnly ? 'bg-gray-100 dark:bg-gray-800' : ''}`}
+                          />
+                          <label className="flex items-center gap-2 text-xs">
+                            <input
+                              type="checkbox"
+                              checked={transform.config.overwrite || false}
+                              disabled={isReadOnly}
+                              onChange={(e) => updateTransformation(transform.id, { config: { overwrite: e.target.checked } })}
+                              className="rounded"
+                            />
+                            Overwrite existing
+                          </label>
+                        </div>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- support new `flatten` and `unflatten` transform ops with default configs
- render configuration inputs for flatten/unflatten operations in the transform UI
- add runtime executor logic and unit tests for flatten/unflatten round-trip and overwrite behavior

## Testing
- `node transformRuntime.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac8fbec6f08322a6db4a5fd36c54dd