### PR TITLE
feat: enhance filter parsing with validation

### DIFF
--- a/filter-utils.js
+++ b/filter-utils.js
@@ -1,0 +1,22 @@
+function parseWhereInput(input) {
+  if (input && typeof input === 'object' && !Array.isArray(input)) {
+    return { kind: 'tree', tree: input };
+  }
+  if (input == null) return null;
+  const text = String(input).trim();
+  if (!text) return null;
+  if (text.startsWith('{') || text.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed === 'object') {
+        return { kind: 'tree', tree: parsed };
+      }
+      throw new Error('Invalid predicate JSON');
+    } catch (err) {
+      throw new Error('Invalid predicate JSON');
+    }
+  }
+  return { kind: 'expr', expr: text };
+}
+
+module.exports = { parseWhereInput };

--- a/filter-utils.test.js
+++ b/filter-utils.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const { parseWhereInput } = require('./filter-utils');
+
+// Expression input
+const expr = parseWhereInput('age > 30');
+assert.deepStrictEqual(expr, { kind: 'expr', expr: 'age > 30' }, 'expression parsing');
+
+// Predicate tree JSON
+const jsonInput = '{"path":"age","op":"gt","value":21}';
+const tree = parseWhereInput(jsonInput);
+assert.deepStrictEqual(tree, {
+  kind: 'tree',
+  tree: { path: 'age', op: 'gt', value: 21 }
+}, 'predicate JSON parsing');
+
+// Invalid JSON
+let errorCaught = false;
+try {
+  parseWhereInput('{invalid');
+} catch (err) {
+  errorCaught = true;
+}
+assert.ok(errorCaught, 'invalid JSON should throw');
+
+console.log('filter-utils tests passed');


### PR DESCRIPTION
## Summary
- switch to explicit filter parser that returns structured expression or tree
- validate filter text, track node errors, and export normalized filter and post_limit operations
- add tests for filter parser covering expression, JSON, and invalid input cases

## Testing
- `node transformRuntime.test.js`
- `node filter-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac950601ac8322997ef9e3ae84b4bb