### PR TITLE
feat: add PathPicker component with schema validation

### DIFF
--- a/PathPicker.js
+++ b/PathPicker.js
@@ -1,0 +1,97 @@
+import React, { useState, useMemo, useId, useEffect } from 'react';
+
+/**
+ * PathPicker provides an autocomplete text input for selecting object paths
+ * based on a provided schema. It validates selections against the schema and
+ * optional type constraints, and shows live preview information.
+ */
+const PathPicker = ({
+  schema = {},
+  value = '',
+  onChange,
+  expectedType,
+  allowCreate = true,
+  previewData,
+  disabled = false,
+  placeholder = 'Target path',
+  className = '',
+}) => {
+  const listId = useId();
+  const paths = useMemo(() => Object.keys(schema || {}), [schema]);
+  const [error, setError] = useState('');
+  const [preview, setPreview] = useState('');
+
+  useEffect(() => {
+    validate(value);
+    updatePreview(value);
+  }, [value, schema, expectedType, allowCreate, previewData]);
+
+  const getValueByPath = (obj, path) => {
+    if (!obj || !path) return undefined;
+    return path.split('.').reduce((o, k) => (o && o[k] !== undefined ? o[k] : undefined), obj);
+  };
+
+  const validate = (v) => {
+    if (!v) {
+      setError('');
+      return;
+    }
+    const entry = schema[v];
+    if (!entry) {
+      if (!allowCreate) {
+        setError('Path not found in schema');
+        return;
+      }
+    } else if (expectedType && entry.type) {
+      const exp = Array.isArray(expectedType) ? expectedType : [expectedType];
+      if (!exp.includes(entry.type)) {
+        setError(`Expected ${exp.join(' or ')} but found ${entry.type}`);
+        return;
+      }
+    }
+    setError('');
+  };
+
+  const updatePreview = (v) => {
+    if (!v) {
+      setPreview('');
+      return;
+    }
+    const entry = schema[v];
+    if (!entry) {
+      setPreview('');
+      return;
+    }
+    const val = previewData ? getValueByPath(previewData, v) : undefined;
+    const sample = val !== undefined ? ` – e.g. ${JSON.stringify(val)}` : '';
+    setPreview(`${entry.type}${sample}`);
+  };
+
+  const handleChange = (e) => {
+    onChange?.(e.target.value);
+  };
+
+  return (
+    <div className="space-y-1">
+      <input
+        type="text"
+        list={listId}
+        value={value}
+        onChange={handleChange}
+        disabled={disabled}
+        placeholder={placeholder}
+        className={className}
+      />
+      <datalist id={listId}>
+        {paths.map(p => (
+          <option key={p} value={p} />
+        ))}
+      </datalist>
+      {preview && <div className="text-xs text-gray-500">Type: {preview}</div>}
+      {error && <div className="text-xs text-red-500">{error}</div>}
+    </div>
+  );
+};
+
+export default PathPicker;
+

--- a/updated_app_api_in_google_v2.js
+++ b/updated_app_api_in_google_v2.js
@@ -32,6 +32,7 @@ import logoLight from './app-integrator-logo-light.svg';
 import logoDark from './app-integrator-logo-dark.svg';
 import apiCatalog from './api-catalog.json';
 import filterUtils from './filter-utils.js';
+import PathPicker from './PathPicker';
 
 const { parseWhereInput } = filterUtils;
 
@@ -48,26 +49,38 @@ const getEnvPermissions = (env) => ENV_SETTINGS[env] || {};
 const TRANSFORM_OPS = {
   rename_fields: {
     label: 'Rename Fields',
+    expectedType: 'object',
+    allowCreate: true,
     defaultConfig: { mappings: [{ from: '', to: '' }] }
   },
   select_fields: {
     label: 'Select Fields',
+    expectedType: 'object',
+    allowCreate: true,
     defaultConfig: { fields: [''] }
   },
   compute_field: {
     label: 'Compute Field',
+    expectedType: null,
+    allowCreate: true,
     defaultConfig: { field: '', expression: '' }
   },
   array_take: {
     label: 'Array Take',
+    expectedType: 'array',
+    allowCreate: false,
     defaultConfig: { count: 1 }
   },
   flatten: {
     label: 'Flatten',
+    expectedType: 'object',
+    allowCreate: true,
     defaultConfig: { delimiter: '.', depth: 0, preserveArrays: false }
   },
   unflatten: {
     label: 'Unflatten',
+    expectedType: 'object',
+    allowCreate: true,
     defaultConfig: { delimiter: '.', overwrite: false }
   }
 };
@@ -4710,6 +4723,8 @@ const NodePropertiesPanel = ({ node, onUpdate, onClose, theme, showToast, config
       id: `transform_${Date.now()}`,
       op,
       target: '',
+      expectedType: def.expectedType,
+      allowCreate: def.allowCreate !== undefined ? def.allowCreate : true,
       config: JSON.parse(JSON.stringify(def.defaultConfig)),
       onError: 'continue'
     };
@@ -4732,6 +4747,8 @@ const NodePropertiesPanel = ({ node, onUpdate, onClose, theme, showToast, config
       const newT = { ...t };
       if (updates.target !== undefined) newT.target = updates.target;
       if (updates.onError !== undefined) newT.onError = updates.onError;
+      if (updates.expectedType !== undefined) newT.expectedType = updates.expectedType;
+      if (updates.allowCreate !== undefined) newT.allowCreate = updates.allowCreate;
       if (updates.config) {
         const clean = {};
         Object.entries(updates.config).forEach(([k, v]) => {
@@ -5157,13 +5174,13 @@ const NodePropertiesPanel = ({ node, onUpdate, onClose, theme, showToast, config
                     </div>
 
                     <div className="space-y-2">
-                      <input
-                        type="text"
-                        list={fieldOptionsId}
-                        placeholder="Target path"
+                      <PathPicker
+                        schema={getSourceSchemaForTransform()}
                         value={transform.target || ''}
-                        readOnly={isReadOnly}
-                        onChange={(e) => updateTransformation(transform.id, { target: e.target.value })}
+                        onChange={(val) => updateTransformation(transform.id, { target: val })}
+                        expectedType={transform.expectedType}
+                        allowCreate={transform.allowCreate}
+                        disabled={isReadOnly}
                         className={`w-full px-2 py-1 text-sm rounded border ${ theme === 'dark' ? 'bg-gray-800 border-gray-600 text-white' : 'bg-white border-gray-300' } ${isReadOnly ? 'bg-gray-100 dark:bg-gray-800' : ''}`}
                       />
 


### PR DESCRIPTION
## Summary
- introduce reusable `<PathPicker>` with autocomplete, schema/type validation, and live preview
- replace transform target text field with `<PathPicker>` and support expected type + allowCreate constraints
- extend transform metadata to carry `expectedType`/`allowCreate`

## Testing
- `node transformRuntime.test.js`
- `node filter-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68acab3e772083229ee9dcbe72d6672a