### PR TITLE
Add configuration validation routine and tests

### DIFF
--- a/validation.js
+++ b/validation.js
@@ -1,0 +1,82 @@
+// Central configuration validation and persistence/export helpers
+function validateConfig(config, schema = {}) {
+  const seenTargets = new Set();
+
+  const isSimplePath = str => /^[A-Za-z0-9_.]+$/.test(str);
+
+  const checkNode = (node, ctx = 'root') => {
+    if (!node) {
+      throw new Error(`Invalid node at ${ctx}`);
+    }
+    if (Array.isArray(node)) {
+      node.forEach((n, i) => checkNode(n, `${ctx}[${i}]`));
+      return;
+    }
+    const { op, target, expectedType, config = {} } = node;
+    if (!target) {
+      throw new Error(`Missing target for op ${op || 'unknown'} at ${ctx}`);
+    }
+    if (schema && target && !schema[target]) {
+      throw new Error(`Unknown target path: ${target}`);
+    }
+    if (
+      expectedType &&
+      schema[target] &&
+      schema[target].type &&
+      schema[target].type !== expectedType
+    ) {
+      throw new Error(
+        `Type mismatch for "${target}": expected ${expectedType} but found ${schema[target].type}`
+      );
+    }
+    if (seenTargets.has(target)) {
+      throw new Error(`Duplicate write to path: ${target}`);
+    }
+    seenTargets.add(target);
+
+    // Expression/binding checks for conditional nodes
+    if (op === 'condition') {
+      const cond = config.if;
+      if (typeof cond === 'string') {
+        if (isSimplePath(cond)) {
+          if (!schema[cond]) {
+            throw new Error(`Unresolved binding: ${cond}`);
+          }
+        } else {
+          try {
+            new Function(`return (${cond});`); // eslint-disable-line no-new-func
+          } catch (err) {
+            throw new Error(`Invalid expression syntax: ${cond}`);
+          }
+        }
+      }
+      if (Array.isArray(config.then)) {
+        config.then.forEach((n, i) => checkNode(n, `${ctx}.then[${i}]`));
+      }
+      if (Array.isArray(config.else)) {
+        config.else.forEach((n, i) => checkNode(n, `${ctx}.else[${i}]`));
+      }
+    }
+  };
+
+  if (Array.isArray(config)) {
+    config.forEach((n, i) => checkNode(n, `root[${i}]`));
+  } else {
+    checkNode(config, 'root');
+  }
+  return true;
+}
+
+function persistConfig(config, schema) {
+  validateConfig(config, schema);
+  // Stub persistence - in real use this would save to a datastore
+  return JSON.parse(JSON.stringify(config));
+}
+
+function exportConfig(config, schema) {
+  validateConfig(config, schema);
+  return JSON.stringify(config);
+}
+
+module.exports = { validateConfig, persistConfig, exportConfig };
+

--- a/validation.test.js
+++ b/validation.test.js
@@ -1,0 +1,65 @@
+const assert = require('assert');
+const { persistConfig, exportConfig } = require('./validation');
+
+const schema = {
+  'user': { type: 'object' },
+  'user.name': { type: 'string' },
+  'user.age': { type: 'number' }
+};
+
+// Missing target
+let threw = false;
+try {
+  persistConfig([{ op: 'flatten' }], schema);
+} catch (err) {
+  threw = true;
+  assert.ok(err.message.includes('Missing target'), 'missing target message');
+}
+assert.ok(threw, 'should throw for missing target');
+
+// Type mismatch
+threw = false;
+try {
+  persistConfig([{ op: 'flatten', target: 'user.name', expectedType: 'number' }], schema);
+} catch (err) {
+  threw = true;
+  assert.ok(err.message.includes('Type mismatch'), 'type mismatch message');
+}
+assert.ok(threw, 'should throw for type mismatch');
+
+// Unresolved binding
+threw = false;
+try {
+  persistConfig([
+    { op: 'condition', target: 'user', config: { if: 'foo.bar', then: [{ op: 'flatten', target: 'user.name' }] } }
+  ], schema);
+} catch (err) {
+  threw = true;
+  assert.ok(err.message.includes('Unresolved binding'), 'unresolved binding message');
+}
+assert.ok(threw, 'should throw for unresolved binding');
+
+// Duplicate writes
+threw = false;
+try {
+  persistConfig([
+    { op: 'flatten', target: 'user.name' },
+    { op: 'unflatten', target: 'user.name' }
+  ], schema);
+} catch (err) {
+  threw = true;
+  assert.ok(err.message.includes('Duplicate write'), 'duplicate write message');
+}
+assert.ok(threw, 'should throw for duplicate writes');
+
+// Export should also validate
+threw = false;
+try {
+  exportConfig([{ op: 'flatten' }], schema);
+} catch (err) {
+  threw = true;
+  assert.ok(err.message.includes('Missing target'), 'export validation message');
+}
+assert.ok(threw, 'exportConfig should validate');
+
+console.log('validation tests passed');


### PR DESCRIPTION
## Summary
- Add central `validateConfig` routine to enforce target presence, schema compatibility, expression syntax, and duplicate write detection
- Ensure validation runs before persisting or exporting configurations
- Introduce unit tests for missing targets, type mismatches, unresolved bindings, and duplicate path writes

## Testing
- `node filter-utils.test.js`
- `node transformRuntime.test.js`
- `node validation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68acbf466830832293a5b8a57c873621