### PR TITLE
Handle default transform errors and empty configs

### DIFF
--- a/transform-ops.js
+++ b/transform-ops.js
@@ -1,0 +1,74 @@
+const TRANSFORM_OPS = {
+  rename_fields: {
+    label: 'Rename Fields',
+    expectedType: 'object',
+    allowCreate: true,
+    defaultConfig: { mappings: [{ from: '', to: '' }] },
+    defaultOnError: 'continue',
+    requiredConfig: ['mappings']
+  },
+  select_fields: {
+    label: 'Select Fields',
+    expectedType: 'object',
+    allowCreate: true,
+    defaultConfig: { fields: [''] },
+    defaultOnError: 'continue',
+    requiredConfig: ['fields']
+  },
+  compute_field: {
+    label: 'Compute Field',
+    expectedType: null,
+    allowCreate: true,
+    defaultConfig: { field: '', expression: '' },
+    defaultOnError: 'continue',
+    requiredConfig: ['field', 'expression']
+  },
+  array_take: {
+    label: 'Array Take',
+    expectedType: 'array',
+    allowCreate: false,
+    defaultConfig: { count: 1 },
+    defaultOnError: 'continue',
+    requiredConfig: ['count']
+  },
+  flatten: {
+    label: 'Flatten',
+    expectedType: 'object',
+    allowCreate: true,
+    defaultConfig: { delimiter: '.', depth: 0, preserveArrays: false },
+    defaultOnError: 'continue',
+    requiredConfig: []
+  },
+  unflatten: {
+    label: 'Unflatten',
+    expectedType: 'object',
+    allowCreate: true,
+    defaultConfig: { delimiter: '.', overwrite: false },
+    defaultOnError: 'continue',
+    requiredConfig: []
+  }
+};
+
+function normalizeTransformations(transforms = []) {
+  const steps = [];
+  transforms.forEach(t => {
+    const def = TRANSFORM_OPS[t.op] || {};
+    const config = t.config || {};
+    if (!config || Object.keys(config).length === 0) return;
+    if ((def.requiredConfig || []).some(key => {
+      const val = config[key];
+      return val === undefined || val === null || val === '' || (Array.isArray(val) && val.length === 0);
+    })) {
+      return;
+    }
+    steps.push({
+      op: t.op,
+      target: t.target,
+      config,
+      onError: t.onError || def.defaultOnError || 'continue'
+    });
+  });
+  return steps;
+}
+
+module.exports = { TRANSFORM_OPS, normalizeTransformations };

--- a/transform-ops.test.js
+++ b/transform-ops.test.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+const { normalizeTransformations } = require('./transform-ops');
+
+const steps = normalizeTransformations([
+  { op: 'flatten', target: 'a', config: {} },
+  { op: 'unflatten', target: 'b', config: { delimiter: '.' } },
+]);
+
+assert.deepStrictEqual(steps, [
+  { op: 'unflatten', target: 'b', config: { delimiter: '.' }, onError: 'continue' }
+], 'should default onError and skip empty configs');
+
+console.log('transform ops tests passed');


### PR DESCRIPTION
## Summary
- Use shared transform-op registry with `defaultOnError` and `requiredConfig` for each op
- Normalize node transformations: skip empty config and default `onError` to `continue`
- Add tests verifying empty configs are ignored and `onError` defaults correctly

## Testing
- `node filter-utils.test.js`
- `node transformRuntime.test.js`
- `node transform-ops.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68acc2987818832282541522d942268b