### PR TITLE
Add user management workflow example

### DIFF
--- a/examples/run-user-workflow.js
+++ b/examples/run-user-workflow.js
@@ -1,0 +1,57 @@
+const { runSteps } = require('../transformRuntime');
+const config = require('./user-workflow-config.json');
+
+function resolveTemplates(obj, context) {
+  if (typeof obj === 'string') {
+    return obj.replace(/{{([^}]+)}}/g, (_, p) => {
+      return p.trim().split('.').reduce((acc, key) => (acc ? acc[key] : undefined), context);
+    });
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(v => resolveTemplates(v, context));
+  }
+  if (obj && typeof obj === 'object') {
+    const out = {};
+    for (const k of Object.keys(obj)) {
+      out[k] = resolveTemplates(obj[k], context);
+    }
+    return out;
+  }
+  return obj;
+}
+
+async function mockCall(node, context) {
+  const variables = resolveTemplates(node.variables || {}, context);
+  console.log(`Calling ${node.id} with`, variables);
+  await new Promise(r => setTimeout(r, 50));
+  return node.mockResponse;
+}
+
+async function run() {
+  const ctx = { input: config.input };
+
+  const userNode = config.workflow.nodes.find(n => n.id === 'getUserDetail');
+  const userRes = await mockCall(userNode, ctx);
+  ctx.user = userRes.data.getUserDetailByUserId;
+
+  const sessionNode = config.workflow.nodes.find(n => n.id === 'getUserWorkingSession');
+  const delegationNode = config.workflow.nodes.find(n => n.id === 'getUserDelegation');
+  const [sessionsRes, delegationsRes] = await Promise.all([
+    mockCall(sessionNode, ctx),
+    mockCall(delegationNode, ctx)
+  ]);
+  ctx.sessions = sessionsRes.data.getUserWorkingSessionByappCodeActionTypeUserId.items;
+  ctx.delegations = delegationsRes.data.getUserDelegationByUserId.items;
+
+  const configNode = config.workflow.nodes.find(n => n.id === 'getCountryConfig');
+  const countryRes = await mockCall(configNode, ctx);
+  ctx.countryConfig = countryRes.data.getUserManagementConfigByCategoryNameAndId;
+
+  const transformNode = config.workflow.nodes.find(n => n.id === 'transform');
+  const output = runSteps(ctx, transformNode.transformations);
+
+  console.log('Final Output:');
+  console.log(JSON.stringify(output, null, 2));
+}
+
+run().catch(err => console.error(err));

--- a/examples/user-workflow-config.json
+++ b/examples/user-workflow-config.json
@@ -1,0 +1,95 @@
+{
+  "input": {
+    "userId": "982652463540121"
+  },
+  "workflow": {
+    "nodes": [
+      {
+        "id": "getUserDetail",
+        "type": "graphql",
+        "endpoint": "https://dev.api-int.usermanagement.data.naqp.toyota.com/graphql",
+        "query": "query($userId:String!){ getUserDetailByUserId(userId:$userId){ userId userFirstName userLastName corpRegionCode }}",
+        "variables": { "userId": "{{input.userId}}" },
+        "mockResponse": {
+          "data": {
+            "getUserDetailByUserId": {
+              "userId": "982652463540121",
+              "userFirstName": "John",
+              "userLastName": "Doe",
+              "corpRegionCode": "US"
+            }
+          }
+        }
+      },
+      {
+        "id": "getUserWorkingSession",
+        "type": "graphql",
+        "endpoint": "https://dev.api-int.usermanagement.data.naqp.toyota.com/graphql",
+        "query": "query($pk:String!){ getUserWorkingSessionByappCodeActionTypeUserId(PK_appCodeActionTypeUserId:$pk, limit:10){ items { actionId actionDate } }}",
+        "variables": { "pk": "Q1TIS_VIN_{{user.userId}}" },
+        "mockResponse": {
+          "data": {
+            "getUserWorkingSessionByappCodeActionTypeUserId": {
+              "items": [
+                { "actionId": "LOGIN", "actionDate": "2022-09-21" }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "getUserDelegation",
+        "type": "graphql",
+        "endpoint": "https://dev.api-int.usermanagement.data.naqp.toyota.com/graphql",
+        "query": "query($userId:String!,$limit:Int!){ getUserDelegationByUserId(userId:$userId, limit:$limit){ items { delegationTask delegationStatus } }}",
+        "variables": { "userId": "{{user.userId}}", "limit": 10 },
+        "mockResponse": {
+          "data": {
+            "getUserDelegationByUserId": {
+              "items": [
+                { "delegationTask": "ApproveOrder", "delegationStatus": "ACTIVE" }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "getCountryConfig",
+        "type": "graphql",
+        "endpoint": "https://dev.api-int.usermanagement.data.naqp.toyota.com/graphql",
+        "query": "query($categoryName:String!,$categoryId:String!){ getUserManagementConfigByCategoryNameAndId(categoryName:$categoryName, categoryId:$categoryId){ categoryName categoryId categoryValues }}",
+        "variables": { "categoryName": "Country", "categoryId": "{{user.corpRegionCode}}" },
+        "mockResponse": {
+          "data": {
+            "getUserManagementConfigByCategoryNameAndId": {
+              "categoryName": "Country",
+              "categoryId": "US",
+              "categoryValues": { "currency": "USD" }
+            }
+          }
+        }
+      },
+      {
+        "id": "transform",
+        "type": "transform",
+        "transformations": [
+          {
+            "op": "rename_fields",
+            "target": "user",
+            "config": {
+              "mappings": [
+                { "from": "userFirstName", "to": "firstName" },
+                { "from": "userLastName", "to": "lastName" }
+              ]
+            }
+          },
+          {
+            "op": "select_fields",
+            "target": "",
+            "config": { "fields": ["user", "sessions", "delegations", "countryConfig"] }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add example configuration and runner for user management pipeline
- demonstrate chaining and parallel mock GraphQL calls with transformations

## Testing
- `node examples/run-user-workflow.js`
- `node transformRuntime.test.js`
- `node transform-ops.test.js`
- `node filter-utils.test.js`
- `node validation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68adcab088888322b0fc67eb06cfaa65