### PR TITLE
Allow root-level targets in validation

### DIFF
--- a/validation.js
+++ b/validation.js
@@ -13,7 +13,9 @@ function validateConfig(config, schema = {}) {
       return;
     }
     const { op, target, expectedType, config = {} } = node;
-    if (!target) {
+    // Allow empty string as a valid target representing the root object.
+    // Only treat undefined or null as missing targets.
+    if (target === undefined || target === null) {
       throw new Error(`Missing target for op ${op || 'unknown'} at ${ctx}`);
     }
     if (schema && target && !schema[target]) {

--- a/validation.test.js
+++ b/validation.test.js
@@ -17,6 +17,15 @@ try {
 }
 assert.ok(threw, 'should throw for missing target');
 
+// Allow empty string target (root)
+threw = false;
+try {
+  persistConfig([{ op: 'flatten', target: '' }], schema);
+} catch (err) {
+  threw = true;
+}
+assert.ok(!threw, 'should allow empty string target');
+
 // Type mismatch
 threw = false;
 try {


### PR DESCRIPTION
## Summary
- permit empty-string targets in workflow validation so root operations pass
- cover root target validation with unit test

## Testing
- `node validation.test.js`
- `node transformRuntime.test.js`
- `node transform-ops.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68add208d5f08322a844eadb7f43a93b