### PR TITLE
Add local workflow execution demo

### DIFF
--- a/userAggregatorDemo.js
+++ b/userAggregatorDemo.js
@@ -1,0 +1,118 @@
+const userAggregatorDemo = {
+  id: 'api_demo_6',
+  name: 'User Aggregator Demo',
+  description: 'Demonstrates combining REST and GraphQL APIs with transformations.',
+  version: '1.0.0',
+  status: 'published',
+  wasPublished: true,
+  createdAt: new Date().toISOString(),
+  modifiedAt: new Date().toISOString(),
+  tags: ['demo', 'aggregator'],
+  applications: ['Demo App'],
+  inputSchema: { userId: { type: 'number', required: true, description: 'JSONPlaceholder user id', example: 1 } },
+  outputSchema: {
+    user: { type: 'object', description: 'User details from REST API' },
+    firstCountry: { type: 'object', description: 'First country from GraphQL API' }
+  },
+  workflow: {
+    nodes: [
+      { id: 'start_1', type: 'start', position: { x: 50, y: 200 }, data: { label: 'Start', status: 'idle' } },
+      {
+        id: 'api_user',
+        type: 'api',
+        position: { x: 200, y: 200 },
+        data: {
+          label: 'Fetch User',
+          apiType: 'REST',
+          method: 'GET',
+          endpoint: 'https://jsonplaceholder.typicode.com/users/{{userId}}',
+          status: 'idle',
+          mockResponse: {
+            id: 1,
+            name: 'Leanne Graham',
+            username: 'Bret',
+            email: 'Sincere@april.biz'
+          }
+        }
+      },
+      {
+        id: 'graphql_countries',
+        type: 'graphql',
+        position: { x: 400, y: 200 },
+        data: {
+          label: 'Fetch Countries',
+          endpoint: 'https://countries.trevorblades.com/',
+          query: 'query { countries { code name } }',
+          variables: {},
+          status: 'idle',
+          mockResponse: {
+            data: {
+              countries: [
+                { code: 'US', name: 'United States' },
+                { code: 'CA', name: 'Canada' }
+              ]
+            }
+          }
+        }
+      },
+      {
+        id: 'transform_1',
+        type: 'transform',
+        position: { x: 600, y: 200 },
+        data: {
+          label: 'Transform',
+          transformations: [
+            {
+              op: 'rename_fields',
+              target: '',
+              config: {
+                mappings: [
+                  { from: 'api_user', to: 'user' },
+                  { from: 'graphql_countries.data.countries.0', to: 'firstCountry' }
+                ]
+              },
+              onError: 'continue'
+            },
+            {
+              op: 'select_fields',
+              target: '',
+              config: { fields: ['user', 'firstCountry'] },
+              onError: 'continue'
+            }
+          ],
+          status: 'idle'
+        }
+      },
+      { id: 'end_1', type: 'end', position: { x: 800, y: 200 }, data: { label: 'End', status: 'idle' } }
+    ],
+    edges: [
+      { id: 'e1', source: 'start_1', target: 'api_user', animated: false },
+      { id: 'e2', source: 'api_user', target: 'graphql_countries', animated: false },
+      { id: 'e3', source: 'graphql_countries', target: 'transform_1', animated: false },
+      { id: 'e4', source: 'transform_1', target: 'end_1', animated: false }
+    ]
+  },
+  environments: {
+    dev: { active: true, variables: {}, promotedVersionId: null, promotedFrom: null, lastPromotion: null, promotionHistory: [] },
+    qa: { active: false, variables: {}, promotedVersionId: null, promotedFrom: null, lastPromotion: null, promotionHistory: [] },
+    uat: { active: false, variables: {}, promotedVersionId: null, promotedFrom: null, lastPromotion: null, promotionHistory: [] },
+    prod: { active: false, variables: {}, promotedVersionId: null, promotedFrom: null, lastPromotion: null, promotionHistory: [] }
+  },
+  versions: [
+    {
+      id: 'v1',
+      version: 1,
+      createdAt: new Date().toISOString(),
+      description: 'Initial version',
+      content: {
+        workflow: { nodes: [], edges: [] },
+        inputSchema: {},
+        outputSchema: {}
+      },
+      isCurrent: true
+    }
+  ],
+  testSuites: []
+};
+
+export default userAggregatorDemo;

--- a/workflow-executor.js
+++ b/workflow-executor.js
@@ -1,0 +1,93 @@
+const transformRuntime = require('./transformRuntime');
+const { runSteps } = transformRuntime;
+
+function resolveTemplates(obj, context) {
+  if (typeof obj === 'string') {
+    return obj.replace(/{{([^}]+)}}/g, (_, p) => {
+      const keys = p.trim().split('.');
+      return keys.reduce((acc, k) => (acc ? acc[k] : undefined), context);
+    });
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(v => resolveTemplates(v, context));
+  }
+  if (obj && typeof obj === 'object') {
+    const out = {};
+    for (const k of Object.keys(obj)) {
+      out[k] = resolveTemplates(obj[k], context);
+    }
+    return out;
+  }
+  return obj;
+}
+
+async function callRest(node, ctx) {
+  const data = node.data || node;
+  let url = resolveTemplates(data.endpoint, ctx);
+  const method = (data.method || 'GET').toUpperCase();
+  const params = resolveTemplates(data.queryParams || data.variables || {}, ctx);
+  const headers = resolveTemplates(data.headers || {}, ctx);
+  let fetchUrl = url;
+  const options = { method, headers: { ...headers } };
+  if (method === 'GET') {
+    const qs = new URLSearchParams(params).toString();
+    if (qs) fetchUrl += (fetchUrl.includes('?') ? '&' : '?') + qs;
+  } else {
+    options.headers['Content-Type'] = 'application/json';
+    options.body = JSON.stringify(params);
+  }
+  try {
+    const res = await fetch(fetchUrl, options);
+    return res.json();
+  } catch (err) {
+    if (data.mockResponse) return data.mockResponse;
+    throw err;
+  }
+}
+
+async function callGraphQL(node, ctx) {
+  const data = node.data || node;
+  const url = resolveTemplates(data.endpoint, ctx);
+  const query = data.query;
+  const variables = resolveTemplates(data.variables || {}, ctx);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, variables })
+    });
+    return res.json();
+  } catch (err) {
+    if (data.mockResponse) return data.mockResponse;
+    throw err;
+  }
+}
+
+async function runWorkflow(config, input = {}, onStep) {
+  let context = { ...input };
+  const nodes = (config.workflow && config.workflow.nodes) || [];
+  for (const node of nodes) {
+    onStep && onStep({ id: node.id, status: 'running' });
+    try {
+      let result;
+      if (node.type === 'api' || node.type === 'rest') {
+        result = await callRest(node, context);
+        context[node.id] = result;
+      } else if (node.type === 'graphql') {
+        result = await callGraphQL(node, context);
+        context[node.id] = result;
+      } else if (node.type === 'transform') {
+        const data = node.data || node;
+        context = runSteps(context, data.transformations || []);
+        result = context;
+      }
+      onStep && onStep({ id: node.id, status: 'success' });
+    } catch (err) {
+      onStep && onStep({ id: node.id, status: 'error', error: err });
+      throw err;
+    }
+  }
+  return context;
+}
+
+module.exports = { runWorkflow };


### PR DESCRIPTION
## Summary
- allow workflow execution directly in the client via new `runWorkflow` helper
- provide `User Aggregator Demo` config combining REST and GraphQL APIs
- wire dashboard "Execute" to run workflows locally and include the new demo config

## Testing
- `node transform-ops.test.js`
- `node filter-utils.test.js`
- `node validation.test.js`
- `node transformRuntime.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68addce8d97c83228bd1323765733e4a